### PR TITLE
Feature: Rework presence notifications.

### DIFF
--- a/peers.py
+++ b/peers.py
@@ -30,50 +30,13 @@ class StorPoolServicePeer(reactive.RelationBase):
         Handle data received from the other units.
         """
         rdebug('relation-joined/changed invoked')
-        try:
-            conv = self.conversation()
-            data = conv.get_remote('storpool_service')
-            if data is None:
-                rdebug('- no service data yet, sending ours then')
-                (state, _) = service_hook.get_state()
-                rdebug('- just making sure we have "-local" in '
-                       'the state array: {have}'
-                       .format(have='-local' in state))
-                conv.set_remote('storpool_service',
-                                json.dumps(state['-local']))
-                rdebug('- done with this hook, it seems')
-                return
-            data = json.loads(data)
-            if not isinstance(data, dict):
-                rdebug('- hmmm, deserialized the service data, but not '
-                       'a dictionary - "{t}" instead'
-                       .format(t=type(data).__name__))
-                return
+        service_hook.handle_remote_presence(self, rdebug=rdebug)
 
-            rdebug('- we got some data from the other side: {data}'
-                   .format(data=data))
-            changed = service_hook.handle(self, True, data, rdebug=rdebug)
-            if changed:
-                rdebug('- looks like something changed when we received '
-                       'the data, sending ours across')
-                (state, _) = service_hook.get_state()
-                rdebug('- got full state: {state}'.format(state=state))
-                conv.set_remote('storpool_service',
-                                json.dumps(state['-local']))
-                rdebug('- looks fine')
-        except Exception as e:
-            rdebug('could not complete the relation '
-                   'joined/changed actions: {e}'.format(e=e))
-
-    @reactive.hook('{peers:storpool-service}-relation-departed')
-    def peer_departed(self):
+    # TODO: handle unit shutdown in a completely different way elsewhere
+    @reactive.hook('{peers:storpool-service}-relation-{departed,broken}')
+    def peer_gone(self):
         """
-        Handle the relation break-down case (all other units departed or
-        this unit being shutdown).
+        Our peers have left the building.
         """
-        rdebug('relation-departed')
-        try:
-            service_hook.handle(self, False, None, rdebug=rdebug)
-        except Exception as e:
-            rdebug('could not complete the relation departed actions: {e}'
-                   .format(e=e))
+        rdebug('relation-departed/broken invoked')
+        self.remove_state('{relation_name}.notify')

--- a/peers.py
+++ b/peers.py
@@ -2,8 +2,6 @@
 A Juju charm interface that helps the `storpool-block` charm keep track of
 which units have been installed and configured.
 """
-import json
-
 from charms import reactive
 
 from spcharms import service_hook

--- a/unit_tests/lib/spcharms/__init__.py
+++ b/unit_tests/lib/spcharms/__init__.py
@@ -2,52 +2,8 @@
 
 import mock
 
-
-class SPServiceHook(object):
-    """
-    Trivially simulate the service_hook utility helper with
-    none of its actual functionality, just record all the calls
-    to the handle() method.
-    """
-    def __init__(self):
-        """
-        Initialize an object with no recorded calls.
-        """
-        self.data = []
-        self.changed = False
-
-    def handle(self, data, rdebug):
-        """
-        Record the arguments passed to the method.
-        """
-        self.data.append((data, rdebug))
-        return self.changed
-
-    def get_data(self):
-        """
-        Return the recorded data.
-        """
-        return list(self.data)
-
-    def clear_data(self):
-        """
-        Clear the recorded data for a new test.
-        """
-        self.data = []
-
-    def get_state(self):
-        """
-        Mock the service_hook's object state dictionary and its "changed" flag.
-        """
-        return ('me!', self.changed)
-
-    def set_changed(self, changed):
-        """
-        Set the "changed" flag for the later get_state() invocations.
-        """
-        self.changed = changed
-
-
 utils = mock.Mock()
+utils.rdebug = mock.Mock()
 
-service_hook = SPServiceHook()
+service_hook = mock.Mock()
+service_hook.handle_remote_presence = mock.Mock()

--- a/unit_tests/lib/spcharms/__init__.py
+++ b/unit_tests/lib/spcharms/__init__.py
@@ -16,11 +16,11 @@ class SPServiceHook(object):
         self.data = []
         self.changed = False
 
-    def handle(self, obj, attaching, data, rdebug):
+    def handle(self, data, rdebug):
         """
         Record the arguments passed to the method.
         """
-        self.data.append((obj, attaching, data, rdebug))
+        self.data.append((data, rdebug))
         return self.changed
 
     def get_data(self):
@@ -39,7 +39,7 @@ class SPServiceHook(object):
         """
         Mock the service_hook's object state dictionary and its "changed" flag.
         """
-        return ({'-local': 'me!'}, self.changed)
+        return ('me!', self.changed)
 
     def set_changed(self, changed):
         """

--- a/unit_tests/test_storpool_service.py
+++ b/unit_tests/test_storpool_service.py
@@ -37,19 +37,6 @@ class TestStorPoolService(unittest.TestCase):
         """
         self.handled.append(args)
 
-    def test_peer_departed(self):
-        """
-        Test that the provider interface sets a reactive state.
-        """
-        obj = testee.StorPoolServicePeer('here-we-are:17')
-
-        service_hook.clear_data()
-        obj.peer_departed()
-        self.assertEquals([(obj, False, None, testee.rdebug)],
-                          service_hook.get_data())
-
-        # That's all, folks!
-
     @mock.patch('peers.StorPoolServicePeer.set_state')
     @mock.patch('peers.StorPoolServicePeer.conversation')
     def test_peer_changed(self, req_conv, set_state):
@@ -69,7 +56,6 @@ class TestStorPoolService(unittest.TestCase):
         obj = testee.StorPoolServicePeer('here-we-are:18')
 
         # No remote data the first time, we send our own.
-        # (make sure we include a "-local" key there...)
         self.remote_state = []
         conv.get_remote.return_value = None
         obj.peer_changed()
@@ -83,7 +69,7 @@ class TestStorPoolService(unittest.TestCase):
         service_hook.clear_data()
         service_hook.set_changed(False)
         obj.peer_changed()
-        self.assertEquals([(obj, True, {'no': 'matter'}, testee.rdebug)],
+        self.assertEquals([({'no': 'matter'}, testee.rdebug)],
                           service_hook.get_data())
         self.assertEquals([], self.remote_state)
 
@@ -93,6 +79,6 @@ class TestStorPoolService(unittest.TestCase):
         service_hook.clear_data()
         service_hook.set_changed(True)
         obj.peer_changed()
-        self.assertEquals([(obj, True, {'1': 2}, testee.rdebug)],
+        self.assertEquals([({'1': 2}, testee.rdebug)],
                           service_hook.get_data())
         self.assertEquals([('storpool_service', '"me!"')], self.remote_state)

--- a/unit_tests/test_storpool_service.py
+++ b/unit_tests/test_storpool_service.py
@@ -8,10 +8,7 @@ import os
 import sys
 import unittest
 
-import json
 import mock
-
-from charms import reactive
 
 root_path = os.path.realpath('.')
 if root_path not in sys.path:
@@ -22,6 +19,8 @@ if lib_path not in sys.path:
     sys.path.insert(0, lib_path)
 
 from spcharms import service_hook
+from spcharms import utils as sputils
+
 
 import peers as testee
 
@@ -31,54 +30,42 @@ class TestStorPoolService(unittest.TestCase):
     Test the data exchanged by the storpool-service interface.
     """
 
-    def record_handled(self, *args):
+    def get_call_count(self, obj):
         """
-        Record a single invocation of service_hook.handled().
+        Fetch the current call count of the tools used.
         """
-        self.handled.append(args)
+        return {
+            'rdebug': sputils.rdebug.call_count,
+            'handle': service_hook.handle_remote_presence.call_count,
+            'remove': obj.remove_state.call_count,
+        }
 
-    @mock.patch('peers.StorPoolServicePeer.set_state')
-    @mock.patch('peers.StorPoolServicePeer.conversation')
-    def test_peer_changed(self, req_conv, set_state):
+    def check_update_call_count(self, obj, ref, delta):
         """
-        Test that the requires interface tries to exchange data.
+        Fetch the current call count and check that the delta is
+        the same as the expected one.
         """
-        def set_remote_state(name, value):
-            """
-            Record all the invocations of conv.set_state() by the charm.
-            """
-            self.remote_state.append((name, value))
+        current = self.get_call_count(obj)
+        for (k, v) in delta.items():
+            ref[k] += v
+        self.assertEqual(current, ref)
 
-        conv = mock.MagicMock(spec=reactive.relations.Conversation)
-        conv.set_remote.side_effect = set_remote_state
-        req_conv.return_value = conv
+    def test_service(self):
+        """
+        Test the data exchanged by the provides interface.
+        """
+        obj = testee.StorPoolServicePeer('storpool-service:42')
+        obj.remove_state = mock.Mock()
+        call_c = self.get_call_count(obj)
 
-        obj = testee.StorPoolServicePeer('here-we-are:18')
-
-        # No remote data the first time, we send our own.
-        self.remote_state = []
-        conv.get_remote.return_value = None
         obj.peer_changed()
-        self.assertEquals([], service_hook.get_data())
-        self.assertEquals([('storpool_service', '"me!"')], self.remote_state)
+        self.check_update_call_count(obj, call_c, {
+            'rdebug': 1,
+            'handle': 1,
+        })
 
-        # Okay then, let's send some data from the other side...
-        # ...but with no change, so no data sent back out.
-        self.remote_state = []
-        conv.get_remote.return_value = json.dumps({'no': 'matter'})
-        service_hook.clear_data()
-        service_hook.set_changed(False)
-        obj.peer_changed()
-        self.assertEquals([({'no': 'matter'}, testee.rdebug)],
-                          service_hook.get_data())
-        self.assertEquals([], self.remote_state)
-
-        # Right, so let's send some data back out now.
-        self.remote_state = []
-        conv.get_remote.return_value = json.dumps({'1': 2})
-        service_hook.clear_data()
-        service_hook.set_changed(True)
-        obj.peer_changed()
-        self.assertEquals([({'1': 2}, testee.rdebug)],
-                          service_hook.get_data())
-        self.assertEquals([('storpool_service', '"me!"')], self.remote_state)
+        obj.peer_gone()
+        self.check_update_call_count(obj, call_c, {
+            'rdebug': 1,
+            'remove': 1,
+        })


### PR DESCRIPTION
Rework the way the StorPool charms (cinder-storpool and storpool-block) notify their own peers and the other charm about the readiness of the units on specific machines and with specific StorPool IDs.