### PR TITLE
Raise a flag when a peer joins.

### DIFF
--- a/peers.py
+++ b/peers.py
@@ -30,7 +30,8 @@ class StorPoolServicePeer(reactive.RelationBase):
         self.set_state('{relation_name}.notify')
         self.set_state('{relation_name}.notify-joined')
 
-    @reactive.hook('{peers:storpool-service}-relation-{changed,departed,broken}')
+    @reactive.hook(
+        '{peers:storpool-service}-relation-{changed,departed,broken}')
     def peer_changed(self):
         """
         Let the main charm handle data received from the other units.

--- a/peers.py
+++ b/peers.py
@@ -21,20 +21,19 @@ class StorPoolServicePeer(reactive.RelationBase):
     """
     scope = reactive.scopes.UNIT
 
-    @reactive.hook('{peers:storpool-service}-relation-{joined,changed}')
+    @reactive.hook('{peers:storpool-service}-relation-joined')
+    def peer_joined(self):
+        """
+        Let the main charm handle data received from the other units.
+        """
+        rdebug('relation-joined invoked')
+        self.set_state('{relation_name}.notify')
+        self.set_state('{relation_name}.notify-joined')
+
+    @reactive.hook('{peers:storpool-service}-relation-{changed,departed,broken}')
     def peer_changed(self):
         """
         Let the main charm handle data received from the other units.
         """
-        rdebug('relation-joined/changed invoked')
-        self.set_state('{relation_name}.present')
+        rdebug('relation-changed/departed/broken invoked')
         self.set_state('{relation_name}.notify')
-
-    @reactive.hook('{peers:storpool-service}-relation-{departed,broken}')
-    def peer_gone(self):
-        """
-        Let the main charm know that our peers have left the building.
-        """
-        rdebug('relation-departed/broken invoked')
-        self.remove_state('{relation_name}.present')
-        self.remove_state('{relation_name}.notify')

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = pep8,unit_tests_35
+envlist = pep8,unit_tests_3
 skipsdist = True
 
-[testenv:unit_tests_35]
-basepython = python3.5
+[testenv:unit_tests_3]
+basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands = ostestr {posargs}
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands =
   flake8 {posargs} *.py

--- a/unit_tests/test_storpool_service.py
+++ b/unit_tests/test_storpool_service.py
@@ -58,14 +58,14 @@ class TestStorPoolService(unittest.TestCase):
         obj.remove_state = mock.Mock()
         call_c = self.get_call_count(obj)
 
-        obj.peer_changed()
+        obj.peer_joined()
         self.check_update_call_count(obj, call_c, {
             'rdebug': 1,
             'set': 2,
         })
 
-        obj.peer_gone()
+        obj.peer_changed()
         self.check_update_call_count(obj, call_c, {
             'rdebug': 1,
-            'remove': 2,
+            'set': 1,
         })


### PR DESCRIPTION
Raise another flag if anything happens (join, change, depart, break),
but handle a peer joining specially to let the charm units announce
their presence to the newcomers.